### PR TITLE
Tyler.hirata/uniquesubstrings

### DIFF
--- a/python/uniqueSubstrings/uniqueSubstrings.py
+++ b/python/uniqueSubstrings/uniqueSubstrings.py
@@ -3,16 +3,33 @@ def uniqueSubstrings(string, k):
     # Gets number of characters in a string
     string_length = len(string)
 
-    # Loop Counter
-    i = 0
+    # define beginning values for the start and end of window
+    window_start = 0
+    window_end = k
+
+    # setting a flag for while loop
+    active = True
+
+    # Creating a list to store unique strings
+    uniqueSubstrings_list = []
 
     # While k is less than or equal to string length loop will continue
-    while k <= string_length:
-        # Prints string using indices.
-        print(string[i:k])
+    while active:
+
+        # Adds each unique substring to a list to be returned
+        substring = string[window_start:window_end]
+        uniqueSubstrings_list.append(substring)
 
         # Adds 1 to each indice each time it loops
-        k = k + 1
-        i = i + 1
+        window_start = window_start + 1
+        window_end = window_end + 1
 
-uniqueSubstrings(")wQ[8]30QvRa", 7)
+        # Check to end loop
+        if window_end > string_length:
+            active = False
+
+    # Returns uniqueSubstrings_list
+    return(uniqueSubstrings_list)
+
+special_strings = uniqueSubstrings("Passw0rd", 4)
+print(special_strings)

--- a/terraform/deploy_cluster_of_web_servers/README.md
+++ b/terraform/deploy_cluster_of_web_servers/README.md
@@ -1,0 +1,4 @@
+Deploy a Cluster of Webservers
+--
+
+Running a single server is a good start, but in the real world a single server is a single point of failure.

--- a/terraform/deploy_cluster_of_web_servers/main.tf
+++ b/terraform/deploy_cluster_of_web_servers/main.tf
@@ -1,0 +1,58 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      version = "~> 6.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}
+
+resource "aws_instance" "ConfigurableWebserver" {
+  ami           = var.ami
+  instance_type = var.instance_type
+  vpc_security_group_ids = [aws_security_group.instance.id]
+
+  user_data = <<-EOF
+            #!/bin/bash
+            echo "hi"
+            echo "Hello, World" > index.html
+            nohup busybox httpd -f -p ${var.server_port} &
+            EOF
+
+  user_data_replace_on_change = true
+
+
+  tags = {
+    Name = "ConfigurableWebserver"
+  }
+}
+
+resource "aws_security_group" "instance" {
+  name = "terraform-ConfigurableWebserver-example-instance"
+
+  ingress{
+    from_port = var.server_port
+    to_port   = var.server_port
+    protocol  = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+# Code to create Launch Configuration
+
+resource "aws_launch_configuration" "example" {
+  image_id = var.ami
+  instance_type = var.instance_type
+  security_groups = [aws_security_group.instance.id]
+
+    user_data = <<-EOF
+            #!/bin/bash
+            echo "hi"
+            echo "Hello, World" > index.html
+            nohup busybox httpd -f -p ${var.server_port} &
+            EOF
+}

--- a/terraform/deploy_cluster_of_web_servers/variables.tf
+++ b/terraform/deploy_cluster_of_web_servers/variables.tf
@@ -1,0 +1,23 @@
+variable "server_port" {
+  description = "The port the server will use for HTTP requests"
+  type        = number
+  default     = 8080
+}
+
+variable "ami" {
+  description = "This is the AMI for the instance"
+  type        = string
+  default     = "ami-05f991c49d264708f"
+}
+
+variable "instance_type" {
+  description = "This is the instance type"
+  type        = string
+  default     = "t2.micro"
+}
+
+variable "region" {
+  description = "This is the AWS region"
+  type        = string
+  default     = "us-west-2"
+}


### PR DESCRIPTION
1. When your Mutating k You’re using k both as the window length and the end index of the slice

```
while k <= string_length:
    print(string[i:k])
    k = k + 1
    i = i + 1
```

2. After the first iteration, k becomes 5, so you’re no longer extracting length‑4 substrings—you’re extracting length‑5, length‑6, etc., until you exit the loop.
3. In the the question was to count unique slices. in your code it prints every window. even if some repeat in a longer string, it doesnt seems to filter them out.
4. Printing vs. returning, any reason for using print to stdout vs returning ?
5. What if k <= 0 or k > len(string)?
6. than manually managing i and k, any other options that are availble for us to use?